### PR TITLE
use MjpegProxy correctly

### DIFF
--- a/server.js
+++ b/server.js
@@ -171,11 +171,9 @@ app.prepare()
    * More on MJPEG over HTTP: https://en.wikipedia.org/wiki/Motion_JPEG#M-JPEG_over_HTTP
    *
   */
-  express.get('/webcam/stream', (req, res) => {
-    const urlData = getURLData(req);
-    // Proxy MJPEG stream from darknet to avoid freezing issues
-    return new MjpegProxy(`http://${urlData.address}:${config.PORTS.darknet_mjpeg_stream}`).proxyRequest(req, res);
-  });
+  express.get('/webcam/stream',
+              // Proxy MJPEG stream from darknet to avoid freezing issues
+              new MjpegProxy(`http://127.0.0.1:${config.PORTS.darknet_mjpeg_stream}`).proxyRequest);
 
   /**
    * @api {get} /webcam/resolution Resolution


### PR DESCRIPTION
reverts this diff: https://github.com/opendatacam/opendatacam/commit/3a7c858bfe4638afea2aafb3a0b5a0267f13c122#diff-78c12f5adc1848d13b1c6f07055d996e

First, the correct URL is `http://localhost:${config.PORTS.darknet_mjpeg_stream}`, not `http://${urlData.address}:${config.PORTS.darknet_mjpeg_stream}`.
The latter can fail, i.e. when putting a load balancer / reverse proxy in front of Opendatacam.

Second: unless I'm missing something, MjpegProxy should only be constructed *once*, and its `proxyRequest` method should be called each time a request arrives. This allows opening a single MPJPEG upstream (darknet) and distributing it to all clients which request it.

I'm not sure why this changed; tagging @tdurand in case there was a particular reason.