### PR TITLE
Feat(GPS): Export GPS timestamp in CSV and JSON

### DIFF
--- a/server.js
+++ b/server.js
@@ -871,16 +871,25 @@ app.prepare()
             area: counterData.areas[countedItem.area].name
           }
 
+          // Adds GPS export fields to CSV
           const isGpsEnabled = config.GPS && config.GPS.enabled === true;
-          const isExportOsmLink = config.GPS && config.GPS.csvExportOpenStreetMapsUrl === true;
-          const isLatLonPresent = countedItem.lat !== null && countedItem.lon !== null;
-          if(isGpsEnabled && isExportOsmLink && isLatLonPresent) {
-            ret.link = `https://www.openstreetmap.org/?mlat=${countedItem.lat}&mlon=${countedItem.lon}#map=19/${countedItem.lat}/${countedItem.lon}`
-          }
+          if(isGpsEnabled) {
+            // Links
+            const isExportOsmLink = config.GPS && config.GPS.csvExportOpenStreetMapsUrl === true;
+            if(isExportOsmLink) {
+              const isLatLonPresent = countedItem.lat !== null && countedItem.lon !== null;
+              if(isLatLonPresent) {
+                ret.link = `https://www.openstreetmap.org/?mlat=${countedItem.lat}&mlon=${countedItem.lon}#map=19/${countedItem.lat}/${countedItem.lon}`;
+              } else {
+                ret.link = null;
+              }
+            }
 
-          const isGpsTimestampPresent = countedItem.gpsTimestamp !== null;
-          if(isGpsEnabled && isGpsTimestampPresent) {
-            ret.gpsTimestamp = countedItem.gpsTimestamp.toISOString();
+            // Timestamp
+            const isGpsTimestampPresent = countedItem.gpsTimestamp !== null;
+            if(isGpsTimestampPresent) {
+              ret.gpsTimestamp = countedItem.gpsTimestamp.toISOString();
+            }
           }
 
           return ret;

--- a/server.js
+++ b/server.js
@@ -878,6 +878,11 @@ app.prepare()
             ret.link = `https://www.openstreetmap.org/?mlat=${countedItem.lat}&mlon=${countedItem.lon}#map=19/${countedItem.lat}/${countedItem.lon}`
           }
 
+          const isGpsTimestampPresent = countedItem.gpsTimestamp !== null;
+          if(isGpsEnabled && isGpsTimestampPresent) {
+            ret.gpsTimestamp = countedItem.gpsTimestamp.toISOString();
+          }
+
           return ret;
         })
       } else {

--- a/server/Opendatacam.js
+++ b/server/Opendatacam.js
@@ -163,12 +163,15 @@ module.exports = {
         angleWithCountingLine: angleWithCountingLine
       }
 
-      // Persist GPS Position if available
+      // Persist GPS Position and timestamp if available
       const hasLat = 'lat' in trackedItem;
       const hasLon = 'lon' in trackedItem;
       if(hasLat && hasLon) {
         countedItem.lat = trackedItem.lat;
         countedItem.lon = trackedItem.lon;
+      }
+      if('gpsTimestamp' in trackedItem) {
+        countedItem.gpsTimestamp = trackedItem.gpsTimestamp;
       }
 
       // Add it to the history

--- a/server/tracker/GpsTracker.js
+++ b/server/tracker/GpsTracker.js
@@ -9,6 +9,8 @@ class GpsTracker {
 
   lat = null;
   lon = null;
+  /** The time obtained from GPS signals as JavaScript Date object */
+  gpsTimestamp = null;
   updateTime = null;
   signalLossTimeoutSeconds = null;
   gpsdListener = null;
@@ -85,6 +87,13 @@ class GpsTracker {
       this.lon = tpv.lon;
       this.updateTime = Date.now();
     }
+    if ("time" in tpv) {
+      try {
+        this.gpsTimestamp = new Date(tpv.time);
+      } catch (error) {
+        this.gpsTimestamp = null;
+      }
+    }
   }
 
   getJSONOfTrackedItems = function (roundInt = true) {
@@ -93,6 +102,7 @@ class GpsTracker {
     // Decorate with GPS data
     const isLatLonPresent = this.lat !== null && this.lon !== null;
     const isFresh = this.updateTime && (Date.now() - this.updateTime <= this.signalLossTimeoutSeconds * 1000);
+    const isGpsTimestampPresent = this.gpsTimestamp !== null;
     ret = ret.map((detectedObject) => {
       if (isLatLonPresent && isFresh) {
         detectedObject.lat = this.lat;
@@ -101,6 +111,13 @@ class GpsTracker {
         detectedObject.lat = null;
         detectedObject.lon = null;
       }
+
+      if(isGpsTimestampPresent && isFresh) {
+        detectedObject.gpsTimestamp = this.gpsTimestamp;
+      } else {
+        detectedObject.gpsTimestamp = null;
+      }
+
       return detectedObject;
     });
 

--- a/server/tracker/GpsTracker.js
+++ b/server/tracker/GpsTracker.js
@@ -11,11 +11,15 @@ class GpsTracker {
   lon = null;
   /** The time obtained from GPS signals as JavaScript Date object */
   gpsTimestamp = null;
-  updateTime = null;
+  /** The system timestamp of the last GPS position fix as JavaScript Date object */
+  positionUpdateTime = null;
+  /** The system timestamp of the last GPS timestamp fix as JavaScript Date object */
+  timeUpdateTime = null;
   signalLossTimeoutSeconds = null;
   gpsdListener = null;
   gpsdReconnectBackoffMillis = this.DEFAULT_GPSD_RECONNECT_BACKUP_MILLIS;
   gpsdReconnectTimer = null;
+  logger = console;
 
   /**
    * Creates a new GPS Tracker to augment the given tracker.
@@ -42,7 +46,7 @@ class GpsTracker {
 
     // Set up the GPS listener and make it automatically reconnect
     this.gpsdListener.on('connected', () => {
-      console.debug('GPSD Connected');
+      this.logger.info('GPSD: Connected');
       this.gpsdReconnectBackoffMillis = this.DEFAULT_GPSD_RECONNECT_BACKUP_MILLIS;
       this.gpsdListener.watch();
     });
@@ -71,7 +75,15 @@ class GpsTracker {
       //    at Socket.emit (events.js:315:20)
       //    at TCP.<anonymous> (net.js:670:12)
       this.gpsdReconnectTimer = setTimeout(() => { this.gpsdListener.connect(); }, this.gpsdReconnectBackoffMillis);
-      console.debug(`GPSD Connection Failed. Retrying in ${this.gpsdReconnectBackoffMillis} milliseconds.`);
+      this.logger.warn(`GPSD: Connection Failed. Retrying in ${this.gpsdReconnectBackoffMillis} milliseconds.`);
+      this.logger.info(`GPSD: Lost GPS position. lat=${this.lat} lon=${this.lon}`);
+      if(this.gpsTimestamp !== null) {
+        this.logger.info(`GPSD: Lost GPS time. gpsTimestamp=${this.gpsTimestamp.toISOString()}`);
+      }
+      this.lon = null;
+      this.lat = null;
+      this.gpsTimestamp = null;
+
     });
     // XXX: Do not remove anonymous function.
     // Similar to above calling directly messes up the "this" reference.
@@ -83,13 +95,27 @@ class GpsTracker {
 
   handleGpsTpvUpdate = function (tpv) {
     if (tpv.lat && tpv.lon) {
+
+      // Log if this is the first position fix we get
+      if(this.lat == null) {
+        this.logger.info(`GPSD: Got GPS position. lat=${tpv.lat} lon=${tpv.lon}`);
+      }
+
       this.lat = tpv.lat;
       this.lon = tpv.lon;
-      this.updateTime = Date.now();
+      this.positionUpdateTime = Date.now();
     }
     if ("time" in tpv) {
       try {
-        this.gpsTimestamp = new Date(tpv.time);
+        const gpsTimestamp = new Date(tpv.time);
+
+        // Log if this is the first time fix we get
+        if(this.gpsTimestamp == null) {
+          this.logger.info(`GPSD: Got GPS time. gpsTimestamp=${gpsTimestamp.toISOString()}`);
+        }
+
+        this.gpsTimestamp = gpsTimestamp;
+        this.timeUpdateTime = Date.now();
       } catch (error) {
         this.gpsTimestamp = null;
       }
@@ -101,20 +127,36 @@ class GpsTracker {
 
     // Decorate with GPS data
     const isLatLonPresent = this.lat !== null && this.lon !== null;
-    const isFresh = this.updateTime && (Date.now() - this.updateTime <= this.signalLossTimeoutSeconds * 1000);
+    const isPositionFresh = this.positionUpdateTime && (Date.now() - this.positionUpdateTime <= this.signalLossTimeoutSeconds * 1000);
     const isGpsTimestampPresent = this.gpsTimestamp !== null;
+    const isGpsTimestamFresh = this.timeUpdateTime && (Date.now() - this.timeUpdateTime <= this.signalLossTimeoutSeconds * 1000);
     ret = ret.map((detectedObject) => {
-      if (isLatLonPresent && isFresh) {
+      if (isLatLonPresent && isPositionFresh) {
         detectedObject.lat = this.lat;
         detectedObject.lon = this.lon;
       } else {
+
+        // Log if we lost the position
+        if(this.lat !== null) {
+          this.logger.info(`GPSD: Lost GPS position. lat=${this.lat} lon=${this.lon}`);
+          this.lat = null;
+          this.lon = null;
+        }
+
         detectedObject.lat = null;
         detectedObject.lon = null;
       }
 
-      if(isGpsTimestampPresent && isFresh) {
+      if(isGpsTimestampPresent && isGpsTimestamFresh) {
         detectedObject.gpsTimestamp = this.gpsTimestamp;
       } else {
+
+        // Log if we lost the time
+        if(this.gpsTimestamp !== null) {
+          this.logger.info(`GPSD: Lost GPS time. gpsTimestamp=${this.gpsTimestamp.toISOString()}`);
+          this.gpsTimestamp = null;
+        }
+
         detectedObject.gpsTimestamp = null;
       }
 


### PR DESCRIPTION
Introduces the timestamp received from GPS as an alternative timestamp in CSV and JSON files. This is useful in situations where Jetson could not sync the system clock due to lack of Internet connection.

# Known Limitations

- GPS timestamp is accurate to 1 second.
- Similar to position, in case of signal loss, the last GPS timestamp will be used for `signalLossTimeoutSeconds` as configured in `config.json`. After that the timestamp will be set to `null`.

Closes #283 