### PR TITLE
Ads EventEmitter API to Opendatacam

### DIFF
--- a/server/Opendatacam.js
+++ b/server/Opendatacam.js
@@ -50,7 +50,7 @@ const initialState = {
   _refTrackedItemIdWhenRecordingStarted: 0,
   sseConnexion: null,
   // Can be true, false or `null` if unknown
-  isSseConnectionOpen = null,
+  isSseConnectionOpen: null,
   recordingStatus: {
     requestedFileRecording: false,
     isRecording: false,

--- a/server/Opendatacam.js
+++ b/server/Opendatacam.js
@@ -369,10 +369,10 @@ module.exports = {
 
     this.sendUpdateToClient();
     if(countedItemsForThisFrame.length > 0 && countedItemsForThisFrame[0] != undefined) {
-      Opendatacam.eventEmitter.emit('count', countedItemsForThisFrame);
+      Opendatacam.eventEmitter.emit('count', countedItemsForThisFrame, frameId);
     }
     if(trackerDataForThisFrame.length > 0) {
-      Opendatacam.eventEmitter.emit('track', trackerDataForThisFrame);
+      Opendatacam.eventEmitter.emit('track', trackerDataForThisFrame, frameId);
     }
   },
 

--- a/server/Opendatacam.js
+++ b/server/Opendatacam.js
@@ -10,6 +10,7 @@ const DBManager = require('./db/DBManager');
 const Logger = require('./utils/Logger');
 const configHelper = require('./utils/configHelper');
 const isInsidePolygon = require('point-in-polygon')
+const { EventEmitter } = require('events');
 
 // YOLO process max retries
 const HTTP_REQUEST_LISTEN_TO_YOLO_RETRY_DELAY_MS = 30;
@@ -68,7 +69,9 @@ const initialState = {
   HTTPRequestListeningToYOLOMaxRetries: HTTP_REQUEST_LISTEN_TO_YOLO_MAX_RETRIES,
   tracker: null,
   // A reference of the yolo object to work with
-  yolo: null
+  yolo: null,
+  /** The event emitter used for all events */
+  eventEmitter: new EventEmitter()
 }
 
 let Opendatacam = cloneDeep(initialState);
@@ -82,10 +85,14 @@ module.exports = {
       const trackerBackup = Opendatacam.tracker;
       trackerBackup.reset();
 
+      // Keep the eventEmitter to not lose subscriptions.
+      const emitterBackup = Opendatacam.eventEmitter;
+
       // Reset counter
       Opendatacam = cloneDeep(initialState);
-      // Restore reference to the reseted tracker
+      // Restore reference to the reseted tracker and event emitter
       Opendatacam.tracker = trackerBackup;
+      Opendatacam.eventEmitter = emitterBackup;
     })
   },
 
@@ -361,7 +368,12 @@ module.exports = {
     }
 
     this.sendUpdateToClient();
-
+    if(countedItemsForThisFrame.length > 0 && countedItemsForThisFrame[0] != undefined) {
+      Opendatacam.eventEmitter.emit('count', countedItemsForThisFrame);
+    }
+    if(trackerDataForThisFrame.length > 0) {
+      Opendatacam.eventEmitter.emit('track', trackerDataForThisFrame);
+    }
   },
 
 
@@ -966,5 +978,13 @@ module.exports = {
 
   setTracker(tracker) {
     Opendatacam.tracker = tracker;
+  },
+
+  on(event, listener) {
+    Opendatacam.eventEmitter.on(event, listener);
+  },
+
+  once(event, listener) {
+    Opendatacam.eventEmitter.once(event, listener);
   }
 }


### PR DESCRIPTION
To decouple the Opendatacam architecture, this pull request adds the [Events API](https://nodejs.org/api/events.html#events_events) to Opendatam.

The following events are implemented so far

- `count` Fired when a counter was incremented, or an object leaves a polygon area
- `track` Fired when an object was tracked in this frame

The events can be consumed as follows

```js
// Event: count 236
// [
//   {
//     frameId: 660,
//     timestamp: 2020-10-30T15:00:54.195Z,
//     area: '671e3aaf-eb2b-4f58-94d6-37ac3f17da8e',
//     name: 'cigarette butt',
//     id: 24,
//     bearing: 184.6858998395027,
//     countingDirection: 'entering_zone',
//     angleWithCountingLine: null
//   }
// ]
Opendatacam.on('count', (data, frameId) => {
    console.log('`Event: count ${{ frameId }}`);
    console.log(data);
});

// Event: track 251
// [
//   {
//     id: 5,
//     x: 648,
//     y: 724,
//     w: 37,
//     h: 34,
//     confidence: 0.32,
//     bearing: 168,
//     name: 'car',
//     isZombie: true,
//     counted: [],
//     areas: []
//   }
// ]
Opendatacam.on('track', (data, frameId) => {
    console.log(`Event: track ${{ frameId }}`);
    console.log(data);
});
```

This API change makes it easier to extend and interact with Opendatacam.

# PR Note

This PR is based on https://github.com/vsaw/opendatacam which includes the following pending PRs

- https://github.com/opendatacam/opendatacam/pull/284
- https://github.com/opendatacam/opendatacam/pull/287
- https://github.com/opendatacam/opendatacam/pull/289
- https://github.com/opendatacam/opendatacam/pull/291
- https://github.com/opendatacam/opendatacam/pull/293
- https://github.com/opendatacam/opendatacam/pull/299

It is therefore recommended to merge this **after** merging the PRs above.