### PR TITLE
fix(YOLO): use proper JSON parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9871,6 +9871,11 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "stream-chain": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.3.tgz",
+      "integrity": "sha512-w+WgmCZ6BItPAD3/4HD1eDiDHRLhjSSyIV+F0kcmmRyz8Uv9hvQF22KyaiAUmOlmX3pJ6F95h+C191UbS8Oe/g=="
+    },
     "stream-each": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
@@ -9890,6 +9895,14 @@
         "readable-stream": "^2.3.6",
         "to-arraybuffer": "^1.0.0",
         "xtend": "^4.0.0"
+      }
+    },
+    "stream-json": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.7.1.tgz",
+      "integrity": "sha512-I7g0IDqvdJXbJ279/D3ZoTx0VMhmKnEF7u38CffeWdF8bfpMPsLo+5fWnkNjO2GU/JjWaRjdH+zmH03q+XGXFw==",
+      "requires": {
+        "stream-chain": "^2.2.3"
       }
     },
     "stream-shift": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "redux-thunk": "^2.3.0",
     "request": "^2.88.2",
     "serve-static": "^1.14.1",
-    "server-sent-events": "^1.0.1"
+    "server-sent-events": "^1.0.1",
+    "stream-json": "^1.7.1"
   },
   "devDependencies": {
     "apidoc": "^0.23.0",

--- a/server/processes/YoloSimulation.js
+++ b/server/processes/YoloSimulation.js
@@ -156,6 +156,7 @@ class YoloSimulation extends YoloDarknet {
     this.simulationJSONHTTPStreamServer = http.createServer((req, res) => {
       console.debug("Got request on JSON Stream server started");
       simulationState.JSONStreamRes = res;
+      res.write("[");
       simulationState.timer = this.startStream(simulationState);
     });
     this.simulationJSONHTTPStreamServer.on('close', (err, socket) => {
@@ -277,7 +278,7 @@ class YoloSimulation extends YoloDarknet {
    */
   static sendYoloJson(stream, detections) {
     if (stream) {
-      stream.write(JSON.stringify(detections));
+      stream.write(JSON.stringify(detections) + ",");
     } else {
       console.warn("JSONStream connection isn't opened yet");
     }


### PR DESCRIPTION
The parser we have now is very fragile... it relies on the application emitting one JSON message in every chunk, and it relies on those chunks arriving exactly the same. Applications should **never** do that, i.e. the network stack can concatenate chunks, split them, etc. Furthermore this breaks on the first message since it has an opening `[`. Also, this calls `chunk.toString()` on every chunk which can result in corrupted text.

Instead, use a JSON streaming parser like [stream-json](https://github.com/uhop/stream-json). It's way more robust and simplifies the code a lot.