### PR TITLE
Fix(Github Action): Run ESLINT

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,3 +24,4 @@ jobs:
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test
+    - run: npm run lint


### PR DESCRIPTION
I thought `npm ci` was triggering eslint, but it looks like we have to start it manually.