### PR TITLE
Doc Update: Jetson Nano instructions generate warnings and errors

### DIFF
--- a/docker/run/nano/docker-compose.yml
+++ b/docker/run/nano/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - "8070:8070"
       - "8090:8090"
   mongo:
-    image: mongo
+    image: mongo:4.4.8
     restart: always
     ports:
       - "27017:27017"

--- a/documentation/jetson/FLASH_JETSON.md
+++ b/documentation/jetson/FLASH_JETSON.md
@@ -18,7 +18,7 @@ jetson_release
 
 # Output should be something like:
 # - NVIDIA Jetson TX2
-#  * Jetpack 4.2 [L4T 32.1.0]
+#  * Jetpack 4.3 [L4T 32.3.1]
 #  * CUDA GPU architecture 6.2
 #  * NV Power Mode: MAXN - Type: 0
 ```
@@ -48,9 +48,9 @@ nvcc --version
 
 #### Jetson TX2 / Jetson Xavier
 
-- Since march 2019, Nvidia has released a SDK manager tool to flash jetson, complete doc is available here: https://docs.nvidia.com/sdk-manager/index.html 
+- Since march 2019, Nvidia has released a SDK manager tool to flash jetson, complete doc is available here: https://docs.nvidia.com/sdk-manager/index.html
 - You need a machine running Ubuntu to install it *(that is not the jetson)*, download link is here: https://developer.nvidia.com/embedded/downloads
-- Then follow the steps of the documentation: https://docs.nvidia.com/sdk-manager/install-with-sdkm-jetson/index.html 
+- Then follow the steps of the documentation: https://docs.nvidia.com/sdk-manager/install-with-sdkm-jetson/index.html
 
 **Common issues:**
 

--- a/documentation/jetson/JETSON_NANO.md
+++ b/documentation/jetson/JETSON_NANO.md
@@ -108,9 +108,9 @@ sudo apt install python3-pip
 
 sudo apt-get install -y libffi-dev
 sudo apt-get install -y python-openssl
-sudo apt-get install libssl-dev
+sudo apt-get install -y libssl-dev
 
-sudo pip3 install docker-compose
+sudo -H pip3 install docker-compose
 ```
 
 And then install OpenDataCam
@@ -196,5 +196,3 @@ You should be able to operate Opendatacam without lag issues.
 #### 9. Build a case
 
 [Here are the steps to set up the Jetson NANO in the Wildlife Cam Casing from Naturebytes.](HOUSING.md)
-
-

--- a/documentation/jetson/JETSON_NANO.md
+++ b/documentation/jetson/JETSON_NANO.md
@@ -110,6 +110,7 @@ sudo apt-get install -y libffi-dev
 sudo apt-get install -y python-openssl
 sudo apt-get install -y libssl-dev
 
+sudo -H pip3 install --upgrade pip
 sudo -H pip3 install docker-compose
 ```
 


### PR DESCRIPTION
In order to avoid running into warning messages and an error when trying to install docker-compose these changes to the documentation ensure that with Jetpack 4.3 everything runs smoothly.