### PR TITLE
Removed purge warnings

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
   "VIDEO_INPUT": "TO_REPLACE_VIDEO_INPUT",
   "NEURAL_NETWORK": "TO_REPLACE_NEURAL_NETWORK",
   "VIDEO_INPUTS_PARAMS": {
-    "file": "opendatacam_videos/demo.mp4",
+    "file": "opendatacam_videos_uploaded/demo.mp4",
     "usbcam": "v4l2src device=/dev/video0 ! video/x-raw, framerate=30/1, width=640, height=360 ! videoconvert ! appsink",
     "raspberrycam": "nvarguscamerasrc ! video/x-raw(memory:NVMM),width=1280, height=720, framerate=30/1, format=NV12 ! nvvidconv ! video/x-raw, format=BGRx, width=640, height=360 ! videoconvert ! video/x-raw, format=BGR ! appsink",
     "remote_cam": "YOUR IP CAM STREAM (can be .m3u8, MJPEG ...), anything supported by opencv",

--- a/ethical_statement.md
+++ b/ethical_statement.md
@@ -1,0 +1,35 @@
+## Preamble
+
+OpenDataCam (ODC) was created as an open-source tool to quantify the world. It is designed to be an accessible, affordable and open-source solution to better understand interactions in urban environments.
+
+To that end, ODC has created a governance structure through which users should utilize in order to abide by the ODC ethical code. This document serves to define this code of ethics, with the objectives of maintaining integrity and trustworthiness through:
+
+*	Protection of the public interest
+*	Demonstration of personal integrity
+*	Showing respect for collaborators
+
+The ODC community is an open, safe and inclusive space fostering sharing and collaboration regardless of age, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual orientation. 
+
+This Code of Conduct applies as a condition of use but we expect everyone in our community to follow it. 
+
+## Protection of the Public Interest
+
+Adherents to this Code are expected to:
+1.	carry out their work with due regard for public health, public safety, human rights and the environment;
+2.	support the integrity of and public trust in ODC and the open-source community at large;
+3.	fully disclose, to relevant parties, any conflicts of interest that exist or might be seen to exist by an independent observer.
+ 
+## Demonstration of Personal Integrity
+
+Adherents to this Code are expected to:
+1.	act with good faith and honesty in their collaborative interactions;
+2.	possess sufficient technical knowledge, as well as awareness of relevant standards, regulations and legislation, in order to assist development of ODC or its use in compliance with the legal requirements of the respective jurisdiction of use;
+3.	respect the creative rights of others and honor patents, copyrights and trademarks. 
+
+## Showing Respect for Collaborators
+
+Adherents to this Code are expected to:
+1.	engage the ODC community and other collaborative working environments as open, safe and inclusive through courtesy and mutual respect;
+2.	be thoughtful in choice of words, to be kind to others, and not to insult, attack, harass, denigrate or discriminate against others;
+3.	use clear and precise ways to express the ideas they are trying to share, considering the language and cultural barriers always present given ODC’s global scope;
+4.	actively seek to welcome newcomers and to mentor, promote, advise, and advance those with potential to have impact in their communities, and as part of our global community.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
   "name": "OpenDataCam",
   "version": "3.0.2",
+  "license" : "MIT license",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/opendatacam/opendatacam.git"
+  },
   "scripts": {
     "dev": "scripts/npm/startServer.sh",
     "lint": "scripts/npm/lint.sh",

--- a/scripts/npm/build.sh
+++ b/scripts/npm/build.sh
@@ -4,5 +4,6 @@
 # If there's no git repository, surpress git errors and use the current directory
 REPO_ROOT=$( git rev-parse --show-toplevel 2> /dev/null || echo . )
 
+npx browserslist@latest --update-db
 $REPO_ROOT/scripts/npm/generateapidoc.sh
 npx next build $REPO_ROOT

--- a/scripts/npm/generateapidoc.sh
+++ b/scripts/npm/generateapidoc.sh
@@ -4,4 +4,5 @@
 # If there's no git repository, surpress git errors and use the current directory
 REPO_ROOT=$( git rev-parse --show-toplevel 2> /dev/null || echo . )
 
-npx apidoc -i $REPO_ROOT -e node_modules/ -o .build/apidoc/
+npx browserslist@latest --update-db
+npx apidoc -i $REPO_ROOT -e node_modules/ -e .build/apidoc -o .build/apidoc/

--- a/scripts/npm/generateapidoc.sh
+++ b/scripts/npm/generateapidoc.sh
@@ -5,4 +5,4 @@
 REPO_ROOT=$( git rev-parse --show-toplevel 2> /dev/null || echo . )
 
 npx browserslist@latest --update-db
-npx apidoc -i $REPO_ROOT -e node_modules/ -e .build/apidoc -o .build/apidoc/
+npx apidoc -i $REPO_ROOT -e node_modules/ -e .build/apidoc/ -o .build/apidoc/

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,4 +12,5 @@ module.exports = {
   },
   variants: {},
   plugins: [],
+  purge: false,
 };


### PR DESCRIPTION
Currently, when you build this branch, there is a warning regarding Tailwind not removing all unused CSS.  I have not gone through every component, but to suppress this warning, we simply need to add `purge: false`.  If we should in fact be purging specific files or directories, we can change this to an array providing those as documented here:  https://tailwindcss.com/docs/optimizing-for-production.